### PR TITLE
[DIT-1724] Add optional ditto-dir input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Ditto github action creates a PR with the most recent Ditto text updates.
 |Name|Required|Description|
 |---|---|---|
 |ditto-api-key|yes|[Generated Ditto API key](https://developer.dittowords.com/api-reference#creating-an-api-key)|
+|root-dir|no|`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository.|
 
 ## Example Workflow
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Ditto github action creates a PR with the most recent Ditto text updates.
 |Name|Required|Description|
 |---|---|---|
 |ditto-api-key|yes|[Generated Ditto API key](https://developer.dittowords.com/api-reference#creating-an-api-key)|
-|root-dir|no|`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository.|
+|ditto-dir|no|`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository.|
 
 ## Example Workflow
 ```

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,6 @@ runs:
       uses: actions/setup-node@v1
       with:
         node-version: 16
-    - name: Collect stats
-      run: cd ${{ github.action_path }} && npm i && npm start
-      shell: bash
     - run: npm install --global @dittowords/cli
       shell: bash
     - uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,10 @@ inputs:
   ditto-api-key:
     description: "Your Ditto API key. More info: https://developer.dittowords.com/api-reference#creating-an-api-key"
     required: true
-  root-dir:
+  ditto-dir:
     description: "`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository."
     required: false
-    default: "."
+    default: "./ditto"
 runs:
   using: "composite"
   steps:
@@ -32,7 +32,7 @@ runs:
         DITTO_API_KEY: ${{ inputs.ditto-api-key }}
       shell: bash
       run: |
-        cd ${{ inputs.root-dir }} && npx ditto-cli pull -m githubActionRequest:true
+        cd ${{ inputs.ditto-dir }}/.. && npx ditto-cli pull -m githubActionRequest:true
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   ditto-api-key:
     description: "Your Ditto API key. More info: https://developer.dittowords.com/api-reference#creating-an-api-key"
     required: true
+  root-dir:
+    description: "`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository."
+    required: false
+    default: "."
 runs:
   using: "composite"
   steps:
@@ -28,7 +32,7 @@ runs:
         DITTO_API_KEY: ${{ inputs.ditto-api-key }}
       shell: bash
       run: |
-        npx ditto-cli pull -m githubActionRequest:true
+        cd ${{ inputs.root-dir }} && npx ditto-cli pull -m githubActionRequest:true
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,5 @@
     "url": "https://github.com/dittowords/ditto-text-updater/issues"
   },
   "homepage": "https://github.com/dittowords/ditto-text-updater#readme",
-  "dependencies": {
-    "gh-action-stats": "^0.0.9"
-  }
+  "dependencies": {}
 }

--- a/stats.js
+++ b/stats.js
@@ -1,7 +1,0 @@
-const collectStats = require('gh-action-stats');
-
-function main() {
-  console.log('Colleting stats');
-}
-
-collectStats(main);


### PR DESCRIPTION
## Overview
Creates an optional `ditto-dir` input for repositories that do not have the `ditto` directory in the root of the project. 

## Test Plan

Testing successfully completed in <env> via:

- [ ] Tested with input omitted: https://github.com/asnewman/kozukai/actions/runs/2490362028
- [ ] Tested with input included https://github.com/asnewman/kozukai/actions/runs/2490372674
