### PR TITLE
Jrod/dit 6933 add optional name input parameter to distinguish prs with multi config setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # ditto-github-action
+
 The Ditto github action creates a PR with the most recent Ditto text updates.
 
 ## Prerequisites
+
 **To include the Ditto GitHub action as a part of your repo's workflow, the repo must have integration with the [Ditto CLI](https://github.com/dittowords/cli).** If your repository does not have a `ditto` directory with a filled-out `config.yml` **as a result of initializing the Ditto CLI** this action will not work.
 
 ## Inputs
-|Name|Required|Description|
-|---|---|---|
-|ditto-api-key|yes|[Generated Ditto API key](https://developer.dittowords.com/api-reference#creating-an-api-key)|
-|ditto-dir|no|`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository. Must include 'ditto' (e.g. `./src/ditto`).|
+
+| Name            | Required | Description                                                                                                                                                  |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ditto-api-key   | yes      | [Generated Ditto API key](https://developer.dittowords.com/api-reference#creating-an-api-key)                                                                |
+| ditto-dir       | no       | `ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository. Must include 'ditto' (e.g. `./src/ditto`). |
+| pr-title-prefix | no       | String to prefix the pull request title with (e.g. "Web App Ditto Updates" would result in a PR titled: `Web App Ditto Updates YYYY-MM-DDT`)                 |
 
 ## Example Workflow
+
 ```
 name: Update Ditto Text
 on: workflow_dispatch
@@ -22,7 +27,32 @@ jobs:
         uses: dittowords/ditto-github-action@v0.2.0
         with:
           ditto-api-key: ${{ secrets.DITTO_API_KEY }}
-```  
+```
+
+### With Multiple Ditto Config files
+
+```
+name: Update Ditto Text
+on: workflow_dispatch
+jobs:
+  UpdateWebDittoText:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Ditto text for Web app and create a PR
+        uses: dittowords/ditto-github-action@v0.2.0
+        with:
+          ditto-api-key: ${{ secrets.DITTO_API_KEY }}
+          ditto-dir: "./web/ditto"
+          pr-title-prefix: "Web Ditto text update"
+
+      - name: Pull Ditto text for iOS app and create a PR
+        uses: dittowords/ditto-github-action@v0.2.0
+        with:
+          ditto-api-key: ${{ secrets.DITTO_API_KEY }}
+          ditto-dir: "./ios/ditto"
+          pr-title-prefix: "iOS App Ditto text update"
+```
+
 This example workflow allows you to [manually start the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) resulting in the creation of a PR.
 
 It is recommended to pass the `ditto-api-key` via a [GitHub secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to prevent your API key from getting exposed to the public.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "`ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository. Must include 'ditto' (e.g. './src/ditto')."
     required: false
     default: "./ditto"
+  pr-title-prefix:
+    description: "String to prefix the pull request title with."
+    required: false
+    default: "Ditto text update"
 runs:
   using: "composite"
   steps:
@@ -33,8 +37,8 @@ runs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
-        commit-message: "ditto: text update ${{ steps.datetime.outputs.datetime }}" 
-        title: Ditto text update ${{ steps.datetime.outputs.datetime  }}
+        commit-message: "ditto: text update ${{ steps.datetime.outputs.datetime }}"
+        title: ${{ inputs.pr-title-prefix }} ${{ steps.datetime.outputs.datetime  }}
         body: Automated change by the Ditto Text Updater action
         branch: ditto-update-${{ steps.datetime.outputs.datetime }}
 branding:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,13 @@
 {
   "name": "ditto-github-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ditto-github-action",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "gh-action-stats": "^0.0.9"
-      }
-    },
-    "node_modules/gh-action-stats": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/gh-action-stats/-/gh-action-stats-0.0.9.tgz",
-      "integrity": "sha512-IfQFY99uIICwbCgZ7LuRnYWT3beq0pfa+v4Fk5gPWORItAu5uUr3XFR/2/DgUzSFDwVcWEb7Idsj3vTPB5a4ww=="
-    }
-  },
-  "dependencies": {
-    "gh-action-stats": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/gh-action-stats/-/gh-action-stats-0.0.9.tgz",
-      "integrity": "sha512-IfQFY99uIICwbCgZ7LuRnYWT3beq0pfa+v4Fk5gPWORItAu5uUr3XFR/2/DgUzSFDwVcWEb7Idsj3vTPB5a4ww=="
+      "version": "1.1.0",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-github-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Ditto github action creates a PR with the most recent Ditto text updates.",
   "main": "stats.js",
   "scripts": {


### PR DESCRIPTION
Adds support for a new input: `pr-title-prefix`. This Input allows overriding the base PR title message to something else to help distinguish multiple PRs pushed for multiple ditto configurations.

Updates action version to 1.1.0.

Updates README with more robust examples and new input documentation