### PR TITLE
[DIT-11523] Pin CLI install to final legacy version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: actions/setup-node@v1
       with:
         node-version: 16
-    - run: npm install --global @dittowords/cli
+    - run: npm install --global @dittowords/cli@4.5.2
       shell: bash
     - uses: actions/checkout@v3
       with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-github-action",
-  "version": "1.1.0",
+  "version": "0.3.1",
   "description": "The Ditto github action creates a PR with the most recent Ditto text updates.",
   "main": "stats.js",
   "scripts": {


### PR DESCRIPTION
## Overview

When we pulled the new CLI out of Beta, we broke this github action for legacy customers, because this action was always installing the latest CLI version and the command to pull from legacy changed with the major version update.

This PR provides a quick fix to unblock legacy customers that are currently using this github action by simply pinning the install to the final legacy version.

After this change is released, I will work on the larger fix to update this action to work properly with both legacy and new Ditto.