### PR TITLE
[DIT-11523] Add support for new and legacy Ditto support using CLI v5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ The Ditto github action creates a PR with the most recent Ditto text updates.
 
 ## Inputs
 
-| Name            | Required | Description                                                                                                                                                  |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ditto-api-key   | yes      | [Generated Ditto API key](https://developer.dittowords.com/api-reference#creating-an-api-key)                                                                |
-| ditto-dir       | no       | `ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository. Must include 'ditto' (e.g. `./src/ditto`). |
-| pr-title-prefix | no       | String to prefix the pull request title with (e.g. "Web App Ditto Updates" would result in a PR titled: `Web App Ditto Updates YYYY-MM-DDT`)                 |
+| Name             | Required | Description                                                                                                                                                  |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ditto-api-key    | yes      | [Generated Ditto API key](https://developer.dittowords.com/api-reference#creating-an-api-key)                                                                |
+| ditto-dir        | no       | `ditto` directory location. Only required if the `ditto` directory is not located at the root of your repository. Must include 'ditto' (e.g. `./src/ditto`). |
+| pr-title-prefix  | no       | String to prefix the pull request title with (e.g. "Web App Ditto Updates" would result in a PR titled: `Web App Ditto Updates YYYY-MM-DDT`)                 |
+| pull-from-legacy | no       | By default, the action will pull from the latest version of Ditto. Set this to true to pull from legacy Ditto projects based on a legacy config file.        |
 
 ## Example Workflow
 
@@ -24,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Ditto text and create a PR
-        uses: dittowords/ditto-github-action@v0.2.0
+        uses: dittowords/ditto-github-action@v1.0.0
         with:
           ditto-api-key: ${{ secrets.DITTO_API_KEY }}
 ```
@@ -39,18 +40,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Ditto text for Web app and create a PR
-        uses: dittowords/ditto-github-action@v0.2.0
+        uses: dittowords/ditto-github-action@v1.0.0
         with:
           ditto-api-key: ${{ secrets.DITTO_API_KEY }}
           ditto-dir: "./web/ditto"
           pr-title-prefix: "Web Ditto text update"
 
       - name: Pull Ditto text for iOS app and create a PR
-        uses: dittowords/ditto-github-action@v0.2.0
+        uses: dittowords/ditto-github-action@v1.0.0
         with:
           ditto-api-key: ${{ secrets.DITTO_API_KEY }}
           ditto-dir: "./ios/ditto"
           pr-title-prefix: "iOS App Ditto text update"
+```
+
+### If you have both new and legacy Ditto content in your application
+
+```
+name: Update Ditto Text
+on: workflow_dispatch
+jobs:
+  UpdateWebDittoText:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Ditto text and create a PR
+        uses: dittowords/ditto-github-action@v1.0.0
+        with:
+          ditto-api-key: ${{ secrets.DITTO_API_KEY }}
+          ditto-dir: "./new/ditto"
+          pr-title-prefix: "New Ditto text update"
+
+      - name: Pull legacy Ditto text and create a PR
+        uses: dittowords/ditto-github-action@v1.0.0
+        with:
+          ditto-api-key: ${{ secrets.DITTO_API_KEY }}
+          ditto-dir: "./legacy/ditto"
+          pr-title-prefix: "Legacy Ditto text update"
+          pull-from-legacy: "true"
 ```
 
 This example workflow allows you to [manually start the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) resulting in the creation of a PR.

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "String to prefix the pull request title with."
     required: false
     default: "Ditto text update"
+  pull-from-legacy:
+    description: "By default, will pull from the latest version of Ditto. Set this to true to pull from legacy Ditto projects based on a legacy config file."
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -23,7 +27,7 @@ runs:
       uses: actions/setup-node@v1
       with:
         node-version: 16
-    - run: npm install --global @dittowords/cli@4.5.2
+    - run: npm install --global @dittowords/cli^5.0.0
       shell: bash
     - uses: actions/checkout@v3
       with:
@@ -33,7 +37,12 @@ runs:
         DITTO_API_KEY: ${{ inputs.ditto-api-key }}
       shell: bash
       run: |
-        cd ${{ inputs.ditto-dir }}/.. && npx ditto-cli pull -m githubActionRequest:true
+        cd ${{ inputs.ditto-dir }}/..
+        if [ "${{ inputs.pull-from-legacy }}" = "true" ]; then
+          npx ditto-cli pull --legacy -m githubActionRequest:true 
+        else
+         npx ditto-cli pull -m githubActionRequest:true
+        fi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-github-action",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "The Ditto github action creates a PR with the most recent Ditto text updates.",
   "main": "stats.js",
   "scripts": {


### PR DESCRIPTION
## Overview

- Updates the CLI version used by this github action to `v5.x`. 
- Adds a new flag, `pull-from-legacy`, which allows users to indicate that they want to use the legacy pull command/config file in order to continue pulling from their legacy projects
- Users with both new and legacy projects can create two separate workflows, one with and one without the flag, pointing to two different ditto directories

Note: This cannot be released until this CLI PR, adding support for the `-m` flag has landed: https://github.com/dittowords/cli/pull/127