### PR TITLE
[DIT-11523] Update env var for CLI v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,8 @@ runs:
         fetch-depth: 0
     - name: Ditto pull
       env:
-        DITTO_API_KEY: ${{ inputs.ditto-api-key }}
+        DITTO_API_KEY: ${{ inputs.ditto-api-key }} # Legacy CLI
+        DITTO_TOKEN: ${{ inputs.ditto-api-key }} # CLI v5
       shell: bash
       run: |
         cd ${{ inputs.ditto-dir }}/..

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Set current date as env variable
       id: datetime
-      run: echo "::set-output name=datetime::$(date +'%Y-%m-%dT-%H%M%S')"
+      run: echo "datetime=$(date +'%Y-%m-%dT-%H%M%S')" >> $GITHUB_OUTPUT
       shell: bash
     - name: Use Node.js
       uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-github-action",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The Ditto github action creates a PR with the most recent Ditto text updates.",
   "main": "stats.js",
   "scripts": {


### PR DESCRIPTION
## Overview

- Starting in CLI `v5.x`, the api key is stored in a different env var from legacy. This PR updates the action.yml to set both env vars to the API key value from inputs
- Additionally, resolves deprecation warnings for the use of `set-outputs` as described here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/